### PR TITLE
Jlisowskyy/async launcher

### DIFF
--- a/radiomics/src/cuda/CMakeLists.txt
+++ b/radiomics/src/cuda/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(CUDA_LIB STATIC ${CUDA_SOURCES})
 set_property(TARGET CUDA_LIB PROPERTY CUDA_ARCHITECTURES 60)
 
 target_include_directories(CUDA_LIB PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}")
+target_compile_definitions(CUDA_LIB PRIVATE ENABLE_TIME_MEASUREMENT)
 
 # ------------------------------
 # Pyradiomics C

--- a/radiomics/src/cuda/async_launcher.cuh
+++ b/radiomics/src/cuda/async_launcher.cuh
@@ -193,10 +193,10 @@ cleanup:
     if (diameters_sq_dev) CUDA_CHECK_EXIT(cudaFreeAsync(diameters_sq_dev, stream));
 
     // Pinned host memory cleanup
-    if (surfaceArea_host) CUDA_CHECK_EXIT(cudaFreeAsync(surfaceArea_host, stream));
-    if (volume_host) CUDA_CHECK_EXIT(cudaFreeAsync(volume_host, stream));
-    if (vertex_count_host) CUDA_CHECK_EXIT(cudaFreeAsync(vertex_count_host, stream));
-    if (diameters_sq_host) CUDA_CHECK_EXIT(cudaFreeAsync(diameters_sq_host, stream));
+    if (surfaceArea_host) CUDA_CHECK_EXIT(cudaFreeHost(surfaceArea_host));
+    if (volume_host) CUDA_CHECK_EXIT(cudaFreeHost(volume_host));
+    if (vertex_count_host) CUDA_CHECK_EXIT(cudaFreeHost(vertex_count_host));
+    if (diameters_sq_host) CUDA_CHECK_EXIT(cudaFreeHost(diameters_sq_host));
 
     END_MEASUREMENT(1);
 

--- a/radiomics/src/cuda/basic_launcher.cuh
+++ b/radiomics/src/cuda/basic_launcher.cuh
@@ -114,8 +114,6 @@ int basic_cuda_launcher(
         END_MEASUREMENT(1);
     }
 
-    START_MEASUREMENT(2, "Volumetric Kernel");
-
     // --- 5. Copy Results (SA, Volume, vertex count) back to Host ---
     CUDA_CHECK_GOTO(cudaMemcpy(&surfaceArea_host, surfaceArea_dev, sizeof(double),
                             cudaMemcpyDeviceToHost), cleanup);
@@ -137,6 +135,8 @@ int basic_cuda_launcher(
                 vertex_count_host, (unsigned long long) max_possible_vertices);
         vertex_count_host = max_possible_vertices;
     }
+
+    START_MEASUREMENT(2, "Volumetric Kernel");
 
     // --- 6. Launch Diameter Kernel (only if vertices were generated) ---
     if (vertex_count_host > 0) {

--- a/radiomics/src/cuda/launcher.cuh
+++ b/radiomics/src/cuda/launcher.cuh
@@ -1,6 +1,25 @@
 #ifndef LAUNCHER_CUH
 #define LAUNCHER_CUH
 
+#define CUDA_CHECK_GOTO(call, label) \
+    do { \
+        cudaStatus = call; \
+        if (cudaStatus != cudaSuccess) { \
+            fprintf(stderr, "CUDA Error at %s:%d - %s: %s\n", \
+                    __FILE__, __LINE__, #call, cudaGetErrorString(cudaStatus)); \
+            goto label; \
+        } \
+    } while (0)
+
+#define CUDA_CHECK_EXIT(call) \
+    do { \
+        cudaError_t status = call; \
+        if (status != cudaSuccess) { \
+            fprintf(stderr, "CUDA Cleanup Error at %s:%d - %s: %s\n", \
+                    __FILE__, __LINE__, #call, cudaGetErrorString(status)); \
+        } \
+    } while (0)
+
 #define CUDA_LAUNCH_SOLUTION(launcher, main_kernel, diam_kernel) \
     launcher( \
         []( \

--- a/radiomics/src/cuda/tables.cuh
+++ b/radiomics/src/cuda/tables.cuh
@@ -1,17 +1,19 @@
 #ifndef TABLES_CUH
 #define TABLES_CUH
 
+#include <cinttypes>
+
 // ------------------------------
 // Data tables
 // ------------------------------
 
-static __constant__ int d_gridAngles[8][3] = {
+static __constant__ int8_t d_gridAngles[8][3] = {
     {0, 0, 0}, {0, 0, 1}, {0, 1, 1},
     {0, 1, 0}, {1, 0, 0}, {1, 0, 1},
     {1, 1, 1}, {1, 1, 0}
 };
 
-static __constant__ int d_triTable[128][16] = {
+static __constant__ int8_t d_triTable[128][16] = {
     {-1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
     {0, 8, 3, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},
     {1, 9, 0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1},

--- a/radiomics/src/cuda/test.cu
+++ b/radiomics/src/cuda/test.cu
@@ -5,8 +5,9 @@
 
 shape_func_t g_ShapeFunctions[MAX_SOL_FUNCTIONS]{};
 shape_2D_func_t g_Shape2DFunctions[MAX_SOL_FUNCTIONS]{};
+const char* g_ShapeFunctionNames[MAX_SOL_FUNCTIONS]{};
 
-int AddShapeFunction(size_t idx, shape_func_t func) {
+int AddShapeFunction(size_t idx, shape_func_t func, const char* name) {
     if (idx >= MAX_SOL_FUNCTIONS) {
         exit(EXIT_FAILURE);
     }
@@ -20,6 +21,8 @@ int AddShapeFunction(size_t idx, shape_func_t func) {
     }
 
     g_ShapeFunctions[idx] = func;
+    g_ShapeFunctionNames[idx] = name ? name : "Unknown function name";
+
     return (int) idx;
 }
 
@@ -86,8 +89,8 @@ SOLUTION_DECL(2);
 SOLUTION_DECL(3);
 
 void RegisterSolutions() {
-    REGISTER_SOLUTION(0);
-    REGISTER_SOLUTION(1);
-    REGISTER_SOLUTION(2);
-    REGISTER_SOLUTION(3);
+    REGISTER_SOLUTION(0, "Basic implementation");
+    REGISTER_SOLUTION(1, "Improved atomics");
+    REGISTER_SOLUTION(2, "Added async data copy");
+    REGISTER_SOLUTION(3, "Added simple shared memory");
 }

--- a/radiomics/src/cuda/test.cuh
+++ b/radiomics/src/cuda/test.cuh
@@ -36,10 +36,11 @@ EXTERN void CleanGPUCache();
 #ifdef __cplusplus
 
 extern "C" shape_func_t g_ShapeFunctions[MAX_SOL_FUNCTIONS];
+extern "C" const char* g_ShapeFunctionNames[MAX_SOL_FUNCTIONS];
 extern "C" shape_2D_func_t g_Shape2DFunctions[MAX_SOL_FUNCTIONS];
 
 int AddShape2DFunction(size_t idx, shape_2D_func_t func);
-int AddShapeFunction(size_t idx, shape_func_t func);
+int AddShapeFunction(size_t idx, shape_func_t func, const char* name = nullptr);
 
 #define SOLUTION_NAME(number) \
     calculate_coefficients_cuda_##number
@@ -48,8 +49,8 @@ int AddShapeFunction(size_t idx, shape_func_t func);
     int SOLUTION_NAME(number)(char *mask, int *size, int *strides, double *spacing, \
                 double *surfaceArea, double *volume, double *diameters)                            \
 
-#define REGISTER_SOLUTION(number) \
-    AddShapeFunction(number, SOLUTION_NAME(number))
+#define REGISTER_SOLUTION(number, name) \
+    AddShapeFunction(number, SOLUTION_NAME(number), name)
 
 #define SOLUTION_2D_DECL(number) \
     int calculate_coefficients2D_cuda_##number(char *mask, int *size, int *strides, double *spacing, \
@@ -65,6 +66,7 @@ extern "C" void RegisterSolutions();
 void RegisterSolutions();
 
 extern shape_func_t g_ShapeFunctions[MAX_SOL_FUNCTIONS];
+extern const char* g_ShapeFunctionNames[MAX_SOL_FUNCTIONS];
 extern shape_2D_func_t g_Shape2DFunctions[MAX_SOL_FUNCTIONS];
 
 #endif // __cplusplus

--- a/radiomics/src/cuda/test/framework.c
+++ b/radiomics/src/cuda/test/framework.c
@@ -246,14 +246,15 @@ static void RunTestOnFunc_(data_ptr_t data, const size_t idx) {
     test_result_t *test_result = AllocResults();
     PREPARE_TEST_RESULT(
         test_result,
-        "Custom implementation with idx: %lu",
-        idx
+        "Custom implementation with idx: %lu and name \"%s\"",
+        idx,
+        g_ShapeFunctionNames[idx]
     );
 
     time_measurement_t measurement;
     PREPARE_DATA_MEASUREMENT(
         measurement,
-        "Custom implementation with idx: %lu",
+        "Full execution time: %lu",
         idx
     );
 
@@ -320,6 +321,17 @@ static void PrintSeparator_(FILE *file, size_t columns) {
 static void DisplayPerfMatrix_(FILE *file, test_result_t *results, size_t results_size, size_t idx) {
     const size_t test_sum = GetTestCount_();
     fprintf(file, "Performance Matrix:\n\n");
+
+    /* Display descriptor table */
+    fprintf(file, "Descriptor table:\n");
+    for (size_t i = 0; i < MAX_SOL_FUNCTIONS; ++i) {
+        if (g_ShapeFunctions[i] == NULL) {
+            continue;
+        }
+
+        fprintf(file, "Function %lu: %s\n", i + 1, g_ShapeFunctionNames[i]);
+    }
+    fprintf(file, "\n");
 
     /* Print upper header - 16 char wide column */
     fputs(" row/col        |", file);

--- a/radiomics/src/cuda/test/framework.h
+++ b/radiomics/src/cuda/test/framework.h
@@ -49,6 +49,7 @@ typedef struct test_result {
 
 typedef struct app_state {
     int verbose_flag;
+    int detailed_flag;
 
     const char **input_files;
     size_t size_files;

--- a/radiomics/src/cuda/test/framework.h
+++ b/radiomics/src/cuda/test/framework.h
@@ -24,6 +24,7 @@ BEGIN_DECL_C
 typedef struct time_measurement {
     uint64_t time_ns;
     char *name;
+    uint32_t retries;
 } time_measurement_t;
 
 #define MAX_MEASUREMENTS 32
@@ -50,6 +51,7 @@ typedef struct test_result {
 typedef struct app_state {
     int verbose_flag;
     int detailed_flag;
+    int num_rep_tests;
 
     const char **input_files;
     size_t size_files;

--- a/radiomics/src/cuda/test/framework.h
+++ b/radiomics/src/cuda/test/framework.h
@@ -11,6 +11,16 @@
 // defines
 // ------------------------------
 
+#ifdef __cplusplus
+#define BEGIN_DECL_C extern "C" {
+#define END_DECL_C }
+#else
+#define BEGIN_DECL_C
+#define END_DECL_C
+#endif // __cplusplus
+
+BEGIN_DECL_C
+
 typedef struct time_measurement {
     uint64_t time_ns;
     char *name;
@@ -47,9 +57,13 @@ typedef struct app_state {
 
     test_result_t results[MAX_RESULTS];
     size_t results_counter;
+
+    test_result_t* current_test;
 } app_state_t;
 
 #define FILE_PATH_SEPARATOR "/"
+
+#define MAIN_MEASUREMENT_NAME "Full execution time"
 
 // ------------------------------
 // Data functions
@@ -101,6 +115,8 @@ void FinalizeTesting();
 
 test_result_t *AllocResults();
 
+test_result_t* GetOngoingTest();
+
 #define PREPARE_TEST_RESULT(test_result, ...) \
     do { \
         char *name = (char *) malloc(256); \
@@ -111,5 +127,7 @@ test_result_t *AllocResults();
 data_ptr_t ParseData(const char *filename);
 
 void CleanupData(data_ptr_t data);
+
+END_DECL_C
 
 #endif // CANCERSOLVER_FRAMEWORK_H

--- a/radiomics/src/cuda/test/inline_measurment.hpp
+++ b/radiomics/src/cuda/test/inline_measurment.hpp
@@ -1,0 +1,21 @@
+#ifndef INLINE_MEASURMENT_HPP
+#define INLINE_MEASURMENT_HPP
+
+#ifdef ENABLE_TIME_MEASUREMENT
+
+#include "test/framework.h"
+
+#define START_MEASUREMENT(idx, ...) \
+    time_measurement measurement_##idx; \
+    PREPARE_DATA_MEASUREMENT(measurement_##idx, __VA_ARGS__)
+
+#define END_MEASUREMENT(idx) \
+    EndMeasurement(&measurement_##idx); \
+    AddDataMeasurement(GetOngoingTest(), measurement_##idx)
+
+#else
+#define START_MEASUREMENT(idx, name) (void)0
+#define END_MEASUREMENT(idx) (void)0
+#endif // ENABLE_TIME_MEASUREMENT
+
+#endif //INLINE_MEASURMENT_HPP

--- a/radiomics/src/cuda/test/loader.c
+++ b/radiomics/src/cuda/test/loader.c
@@ -1,5 +1,7 @@
 #include "loader.h"
 
+#define NPY_NO_DEPRECATED_API NPY_1_7_API_VERSION
+
 #include <debug_macros.h>
 #include <framework.h>
 #include <Python.h>


### PR DESCRIPTION
This pull request introduces several enhancements and refactorings to the CUDA launchers in the `radiomics` project, focusing on improving error handling, adding performance measurements, and utilizing asynchronous operations. The most important changes include the addition of error-checking macros, the integration of performance measurement macros, and the use of asynchronous CUDA operations.

### Error Handling Improvements:
* Added `CUDA_CHECK_GOTO` and `CUDA_CHECK_EXIT` macros to `radiomics/src/cuda/launcher.cuh` for consistent error handling and cleanup in CUDA operations.

### Performance Measurement:
* Integrated performance measurement macros (`START_MEASUREMENT` and `END_MEASUREMENT`) in `radiomics/src/cuda/async_launcher.cuh` and `radiomics/src/cuda/basic_launcher.cuh` to track execution time of different stages. [[1]](diffhunk://#diff-015406cc5a2e95693bcd83d3c77c1db29dc31ccf63d867a2a96ed9cac6a57095R23-R24) [[2]](diffhunk://#diff-015406cc5a2e95693bcd83d3c77c1db29dc31ccf63d867a2a96ed9cac6a57095L152-R139) [[3]](diffhunk://#diff-015406cc5a2e95693bcd83d3c77c1db29dc31ccf63d867a2a96ed9cac6a57095L222-R201) [[4]](diffhunk://#diff-ce7d985e75c251fc37607ddca21deda35dd1aa25e0123d2eb1ac7b049549ec8aR21-R22) [[5]](diffhunk://#diff-ce7d985e75c251fc37607ddca21deda35dd1aa25e0123d2eb1ac7b049549ec8aR96) [[6]](diffhunk://#diff-ce7d985e75c251fc37607ddca21deda35dd1aa25e0123d2eb1ac7b049549ec8aR171-R184)

### Asynchronous Operations:
* Replaced synchronous memory allocation and copying with asynchronous versions (`cudaMallocAsync`, `cudaMemcpyAsync`, `cudaFreeAsync`) in `radiomics/src/cuda/async_launcher.cuh` and `radiomics/src/cuda/basic_launcher.cuh` to improve performance. [[1]](diffhunk://#diff-015406cc5a2e95693bcd83d3c77c1db29dc31ccf63d867a2a96ed9cac6a57095L72-R96) [[2]](diffhunk://#diff-015406cc5a2e95693bcd83d3c77c1db29dc31ccf63d867a2a96ed9cac6a57095L191-R165) [[3]](diffhunk://#diff-ce7d985e75c251fc37607ddca21deda35dd1aa25e0123d2eb1ac7b049549ec8aL59-R86) [[4]](diffhunk://#diff-ce7d985e75c251fc37607ddca21deda35dd1aa25e0123d2eb1ac7b049549ec8aL142-R125) [[5]](diffhunk://#diff-ce7d985e75c251fc37607ddca21deda35dd1aa25e0123d2eb1ac7b049549ec8aL190-R158)

### Additional Includes:
* Added `#include "test/inline_measurment.hpp"` to `radiomics/src/cuda/async_launcher.cuh` and `radiomics/src/cuda/basic_launcher.cuh` for performance measurement functionality. [[1]](diffhunk://#diff-015406cc5a2e95693bcd83d3c77c1db29dc31ccf63d867a2a96ed9cac6a57095R6-R7) [[2]](diffhunk://#diff-ce7d985e75c251fc37607ddca21deda35dd1aa25e0123d2eb1ac7b049549ec8aR5)

### Code Refactoring:
* Refactored memory allocation and initialization error handling to use `CUDA_CHECK_GOTO` for cleaner and more consistent error handling in `radiomics/src/cuda/async_launcher.cuh` and `radiomics/src/cuda/basic_launcher.cuh`. [[1]](diffhunk://#diff-015406cc5a2e95693bcd83d3c77c1db29dc31ccf63d867a2a96ed9cac6a57095L54-R61) [[2]](diffhunk://#diff-015406cc5a2e95693bcd83d3c77c1db29dc31ccf63d867a2a96ed9cac6a57095L152-R139) [[3]](diffhunk://#diff-ce7d985e75c251fc37607ddca21deda35dd1aa25e0123d2eb1ac7b049549ec8aL59-R86) [[4]](diffhunk://#diff-ce7d985e75c251fc37607ddca21deda35dd1aa25e0123d2eb1ac7b049549ec8aL142-R125) [[5]](diffhunk://#diff-ce7d985e75c251fc37607ddca21deda35dd1aa25e0123d2eb1ac7b049549ec8aL190-R158)